### PR TITLE
Proposal: dont return observable from createContainer

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,30 +23,21 @@ function createContainer(Component, observables = {}, observers = {}, props = {}
     };
   });
 
-  return Observable.defer(() => {
-    const propsObservable = Object.keys(observables).length === 0
-      ? Observable.of([{}])
-      : combineLatestObj(observables).share();
+  const propsObservable = Object.keys(observables).length === 0
+    ? Observable.of([{}])
+    : combineLatestObj(observables).share();
 
-    const initialState = {};
+  const initialState = {};
 
-    const renderFn = () => (
-      <RxContainer
-        props={props}
-        callbacks={callbacks}
-        initialState={initialState}
-        component={Component}
-        observable={propsObservable}
-      />
-    );
-
-    return propsObservable
-      .do(state => {
-        Object.assign(initialState, state);
-      })
-      .mapTo(renderFn)
-      .distinctUntilChanged();
-  });
+  return (initialProps) => (
+    <RxContainer
+      props={{...initialProps, ...props}}
+      callbacks={callbacks}
+      initialState={initialState}
+      component={Component}
+      observable={propsObservable}
+    />
+  );
 }
 
 export default createContainer;


### PR DESCRIPTION
I could not use your lib in a normal reactjs app without removing the observable defer stuff. This is a general suggestion on how to make your lib usable in a standard non isomorphic app. Maybe you can incorporate it somehow as an option? 